### PR TITLE
[MIN-55] 가입된 계정 로그인 시 토큰 반환 및 유효하지 않은 토큰 예외 처리

### DIFF
--- a/src/main/java/com/mineme/server/user/service/KakaoAuthService.java
+++ b/src/main/java/com/mineme/server/user/service/KakaoAuthService.java
@@ -1,7 +1,5 @@
 package com.mineme.server.user.service;
 
-import javax.validation.ConstraintViolationException;
-
 import com.mineme.server.common.enums.ErrorCode;
 import com.mineme.server.common.exception.CustomException;
 import com.mineme.server.entity.User;
@@ -17,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Service
 @Slf4j
@@ -31,16 +30,18 @@ public class KakaoAuthService {
 	public UserDto.Jwt getKakaoUserDetails(UserDto.SignRequest dto) {
 		try {
 			KakaoUserDto.User user = HttpClientUtil.getMonoUser(dto).block();
-			User signedUser = userRepository.findByUsername(user.getId())
-				.orElse(userRepository.save(User.toPendingUserEntity(user.getId(), dto)));
+			User signedUser = userRepository.findByUsername(user.getId()).orElse(null);
+
+			if (signedUser == null)
+				signedUser = userRepository.save(User.toPendingUserEntity(user.getId(), dto));
 
 			String accessToken = jwtTokenProvider.create(signedUser.getUsername(), properties.getSecret());
 
 			return new UserDto.Jwt(accessToken, signedUser.getUserCode());
-		} catch (ConstraintViolationException e) {
-			throw new CustomException(ErrorCode.USER_EXISTED);
-		} catch (NullPointerException e) {
+		} catch (NullPointerException e) { // @Todo - 추후 orElse() 로직 변경 시 함께 조정해야 함.
 			throw new CustomException(ErrorCode.INVALID_USER);
+		} catch (WebClientResponseException e) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 }


### PR DESCRIPTION
## Update
- [x] Hot Fix
- [ ] Release
- [ ] Develop
- [ ] Others

## Description
* Fix #20 

## New/Edited policies
- 가입된 계정 로그인 시 토큰 반환을 반환하도록 처리하였습니다.
- 유효하지 않은 토큰으로 계정 scope를 요청할 시 발생하는 `Webflux` 예외를 처리하였습니다.
