### PR TITLE
[MIN-72] 스프링 시큐리티의 예외를 글로벌 핸들러로 처리

### DIFF
--- a/src/main/java/com/mineme/server/common/dto/ResponseDto.java
+++ b/src/main/java/com/mineme/server/common/dto/ResponseDto.java
@@ -50,7 +50,7 @@ public class ResponseDto<T> {
 			.body(ResponseDto.builder()
 				.success(false)
 				.data(null)
-				.error(new ExceptionDto(ErrorCode.INVALID_TOKEN)).build());
+				.error(new ExceptionDto(e.getErrorCode())).build());
 	}
 
 	// 그 외 Exception 에 따른 ExceptionDto 리턴

--- a/src/main/java/com/mineme/server/common/dto/ResponseDto.java
+++ b/src/main/java/com/mineme/server/common/dto/ResponseDto.java
@@ -6,6 +6,7 @@ import org.springframework.lang.Nullable;
 
 import com.mineme.server.common.enums.ErrorCode;
 import com.mineme.server.common.exception.CustomException;
+import com.mineme.server.common.exception.CustomJwtException;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +42,15 @@ public class ResponseDto<T> {
 				.success(false)
 				.data(null)
 				.error(new ExceptionDto(e.getErrorCode())).build());
+	}
+
+	// Jwt 인증 예외
+	public static ResponseEntity<Object> toResponseEntity(CustomJwtException e) {
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+			.body(ResponseDto.builder()
+				.success(false)
+				.data(null)
+				.error(new ExceptionDto(ErrorCode.INVALID_TOKEN)).build());
 	}
 
 	// 그 외 Exception 에 따른 ExceptionDto 리턴

--- a/src/main/java/com/mineme/server/common/enums/ErrorCode.java
+++ b/src/main/java/com/mineme/server/common/enums/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 	INVALID_GENDER_FORMAT(4016, HttpStatus.BAD_REQUEST, "Gender format is invalid."),
 	INVALID_USER_STATE(4017, HttpStatus.UNAUTHORIZED, "Invalid User state."),
 
-	INVALID_COUPLE(40017, HttpStatus.BAD_REQUEST, "You can't matching user to couple."),
+	INVALID_COUPLE(4018, HttpStatus.BAD_REQUEST, "You can't matching user to couple."),
+	INVALID_TOKEN_FORMAT(4019, HttpStatus.UNAUTHORIZED, "Invalid Token format."),
 
 	/* File Error */
 	FILE_CONVERT(5001, HttpStatus.INTERNAL_SERVER_ERROR, "File conversion failed"),

--- a/src/main/java/com/mineme/server/common/enums/ErrorCode.java
+++ b/src/main/java/com/mineme/server/common/enums/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 
 	INVALID_COUPLE(4018, HttpStatus.BAD_REQUEST, "You can't matching user to couple."),
 	INVALID_TOKEN_FORMAT(4019, HttpStatus.UNAUTHORIZED, "Invalid Token format."),
+	NULL_TOKEN(4020, HttpStatus.UNAUTHORIZED, "Token is null."),
 
 	/* File Error */
 	FILE_CONVERT(5001, HttpStatus.INTERNAL_SERVER_ERROR, "File conversion failed"),

--- a/src/main/java/com/mineme/server/common/exception/CustomJwtException.java
+++ b/src/main/java/com/mineme/server/common/exception/CustomJwtException.java
@@ -1,0 +1,12 @@
+package com.mineme.server.common.exception;
+
+import com.mineme.server.common.enums.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomJwtException extends RuntimeException {
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/mineme/server/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mineme/server/common/handler/GlobalExceptionHandler.java
@@ -21,6 +21,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(value = {Exception.class})
 	public ResponseEntity<Object> handleException(Exception e) {
+		e.printStackTrace();
 		log.error("handleException throw Exception : {}", e.getMessage());
 		return ResponseDto.toResponseEntity(e);
 	}

--- a/src/main/java/com/mineme/server/common/handler/GlobalJwtExceptionHandler.java
+++ b/src/main/java/com/mineme/server/common/handler/GlobalJwtExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.mineme.server.common.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.mineme.server.common.dto.ResponseDto;
+import com.mineme.server.common.exception.CustomJwtException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice(value = "authenticationExceptionAdvice")
+@Slf4j
+public class GlobalJwtExceptionHandler extends ResponseEntityExceptionHandler {
+
+	@ExceptionHandler({CustomJwtException.class})
+	@ResponseBody
+	public ResponseEntity<Object> handleJwtException(CustomJwtException e) {
+		log.error("handleJwtException throw JwtException : {}", e.getErrorCode().getMessage());
+		return ResponseDto.toResponseEntity(e);
+	}
+}

--- a/src/main/java/com/mineme/server/security/config/SecurityConfig.java
+++ b/src/main/java/com/mineme/server/security/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.mineme.server.security.filter.JwtAuthenticationFilter;
+import com.mineme.server.security.filter.JwtExceptionFilter;
+import com.mineme.server.security.filter.JwtGlobalEntryPoint;
 import com.mineme.server.security.provider.JwtTokenProvider;
 import com.mineme.server.security.provider.UserJwtAuthenticationProvider;
 import com.mineme.server.security.service.CustomUserDetailsService;
@@ -23,6 +25,8 @@ import com.mineme.server.security.service.CustomUserDetailsService;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	private final CustomUserDetailsService userDetailsService;
+	private final JwtGlobalEntryPoint jwtGlobalEntryPoint;
+	private final JwtExceptionFilter jwtExceptionFilter;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final Properties properties;
 
@@ -43,14 +47,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http.httpBasic()
 			.disable()
-			.sessionManagement()
-			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 			.authorizeRequests()
-			.antMatchers("/**")
-			.permitAll()    // @Todo URI 결정 후 접근 제어 변경
+			.antMatchers("/api/v1/auth/**").permitAll()
+			.and()
+			.authorizeRequests()
+			.anyRequest().authenticated()
+			.and()
+			.exceptionHandling().authenticationEntryPoint(jwtGlobalEntryPoint)
 			.and()
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, properties),
-				UsernamePasswordAuthenticationFilter.class);
+				UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 	}
 }

--- a/src/main/java/com/mineme/server/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mineme/server/security/filter/JwtAuthenticationFilter.java
@@ -31,7 +31,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		String token = jwtTokenProvider.resolve(request);
 
-		if (token == null || jwtTokenProvider.validate(token, properties.getSecret()))
+		if (token == null)
+			throw new CustomJwtException(ErrorCode.NULL_TOKEN);
+
+		if (!jwtTokenProvider.validate(token, properties.getSecret()))
 			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 
 		Authentication authentication = jwtTokenProvider.getAuthentication(token, properties.getSecret());

--- a/src/main/java/com/mineme/server/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mineme/server/security/filter/JwtAuthenticationFilter.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.mineme.server.common.enums.ErrorCode;
+import com.mineme.server.common.exception.CustomJwtException;
 import com.mineme.server.security.config.Properties;
 import com.mineme.server.security.provider.JwtTokenProvider;
 
@@ -29,10 +31,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		String token = jwtTokenProvider.resolve(request);
 
-		if (token != null && jwtTokenProvider.validate(token, properties.getSecret())) {
-			Authentication authentication = jwtTokenProvider.getAuthentication(token, properties.getSecret());
-			SecurityContextHolder.getContext().setAuthentication(authentication);
-		}
+		if (token == null || jwtTokenProvider.validate(token, properties.getSecret()))
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
+
+		Authentication authentication = jwtTokenProvider.getAuthentication(token, properties.getSecret());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		chain.doFilter(request, response);
 	}

--- a/src/main/java/com/mineme/server/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/mineme/server/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,44 @@
+package com.mineme.server.security.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.mineme.server.common.enums.ErrorCode;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (SecurityException e) {
+			request.setAttribute("exception", ErrorCode.INVALID_TOKEN_SIGNATURE.getCode());
+		} catch (MalformedJwtException e) {
+			request.setAttribute("exception", ErrorCode.INVALID_TOKEN_FORMAT.getCode());
+		} catch (ExpiredJwtException e) {
+			request.setAttribute("exception", ErrorCode.TOKEN_EXPIRED.getCode());
+		} catch (UnsupportedJwtException e) {
+			request.setAttribute("exception", ErrorCode.UNSUPPORTED_TOKEN.getCode());
+		} catch (IllegalArgumentException e) {
+			request.setAttribute("exception", ErrorCode.EMPTY_TOKEN_CLAIMS.getCode());
+		} catch (Exception e) {
+			request.setAttribute("exception", ErrorCode.INVALID_TOKEN.getCode());
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/com/mineme/server/security/filter/JwtGlobalEntryPoint.java
+++ b/src/main/java/com/mineme/server/security/filter/JwtGlobalEntryPoint.java
@@ -1,0 +1,58 @@
+package com.mineme.server.security.filter;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.simple.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.mineme.server.common.enums.ErrorCode;
+
+@Component("jwtGlobalEntryPoint")
+public class JwtGlobalEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+		Integer exception = (Integer)request.getAttribute("exception");
+
+		if (exception == null) {
+			setResponse(response, ErrorCode.INVALID_REQUEST);
+		} else if (exception.equals(ErrorCode.EMPTY_TOKEN_CLAIMS.getCode())) {
+			setResponse(response, ErrorCode.EMPTY_TOKEN_CLAIMS);
+		} else if (exception.equals(ErrorCode.INVALID_TOKEN_SIGNATURE.getCode())) {
+			setResponse(response, ErrorCode.INVALID_TOKEN_SIGNATURE);
+		} else if (exception.equals(ErrorCode.INVALID_TOKEN.getCode())) {
+			setResponse(response, ErrorCode.INVALID_TOKEN);
+		} else if (exception.equals(ErrorCode.TOKEN_EXPIRED.getCode())) {
+			setResponse(response, ErrorCode.TOKEN_EXPIRED);
+		} else if (exception.equals(ErrorCode.UNSUPPORTED_TOKEN.getCode())) {
+			setResponse(response, ErrorCode.UNSUPPORTED_TOKEN);
+		} else if (exception.equals(ErrorCode.INVALID_TOKEN_FORMAT.getCode())) {
+			setResponse(response, ErrorCode.INVALID_TOKEN_FORMAT);
+		} else {
+			setResponse(response, ErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	private void setResponse(HttpServletResponse response, ErrorCode code) throws IOException {
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType("application/json");
+
+		JSONObject responseJson = new JSONObject();
+		JSONObject errorJson = new JSONObject();
+		errorJson.put("code", code.getCode());
+		errorJson.put("message", code.getMessage());
+
+		responseJson.put("success", false);
+		responseJson.put("data", null);
+		responseJson.put("error", errorJson);
+
+		response.getWriter().print(responseJson);
+	}
+}

--- a/src/main/java/com/mineme/server/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/mineme/server/security/provider/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.mineme.server.security.provider;
 
 import com.mineme.server.common.enums.ErrorCode;
-import com.mineme.server.common.exception.CustomException;
+import com.mineme.server.common.exception.CustomJwtException;
 import com.mineme.server.entity.User;
 import com.mineme.server.entity.enums.UserState;
 import com.mineme.server.security.service.CustomUserDetailsService;
@@ -22,9 +22,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Date;
 
-/**
- * @todo 애플 인가 작업 후 일괄 예외처리 핸들러로 넘길 예정
- */
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -63,22 +60,22 @@ public class JwtTokenProvider {
 			return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
 		} catch (SecurityException e) {
 			log.error(ErrorCode.INVALID_TOKEN_SIGNATURE.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN_SIGNATURE);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN_SIGNATURE);
 		} catch (MalformedJwtException e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		} catch (ExpiredJwtException e) {
 			log.error(ErrorCode.TOKEN_EXPIRED.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+			throw new CustomJwtException(ErrorCode.TOKEN_EXPIRED);
 		} catch (UnsupportedJwtException e) {
 			log.error(ErrorCode.UNSUPPORTED_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+			throw new CustomJwtException(ErrorCode.UNSUPPORTED_TOKEN);
 		} catch (IllegalArgumentException e) {
 			log.error(ErrorCode.EMPTY_TOKEN_CLAIMS.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.EMPTY_TOKEN_CLAIMS);
+			throw new CustomJwtException(ErrorCode.EMPTY_TOKEN_CLAIMS);
 		} catch (Exception e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 
@@ -87,22 +84,22 @@ public class JwtTokenProvider {
 			return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
 		} catch (SecurityException e) {
 			log.error(ErrorCode.INVALID_TOKEN_SIGNATURE.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN_SIGNATURE);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN_SIGNATURE);
 		} catch (MalformedJwtException e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		} catch (ExpiredJwtException e) {
 			log.error(ErrorCode.TOKEN_EXPIRED.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+			throw new CustomJwtException(ErrorCode.TOKEN_EXPIRED);
 		} catch (UnsupportedJwtException e) {
 			log.error(ErrorCode.UNSUPPORTED_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+			throw new CustomJwtException(ErrorCode.UNSUPPORTED_TOKEN);
 		} catch (IllegalArgumentException e) {
 			log.error(ErrorCode.EMPTY_TOKEN_CLAIMS.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.EMPTY_TOKEN_CLAIMS);
+			throw new CustomJwtException(ErrorCode.EMPTY_TOKEN_CLAIMS);
 		} catch (Exception e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 
@@ -129,22 +126,22 @@ public class JwtTokenProvider {
 			return true;
 		} catch (SecurityException e) {
 			log.error(ErrorCode.INVALID_TOKEN_SIGNATURE.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN_SIGNATURE);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN_SIGNATURE);
 		} catch (MalformedJwtException e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		} catch (ExpiredJwtException e) {
 			log.error(ErrorCode.TOKEN_EXPIRED.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+			throw new CustomJwtException(ErrorCode.TOKEN_EXPIRED);
 		} catch (UnsupportedJwtException e) {
 			log.error(ErrorCode.UNSUPPORTED_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+			throw new CustomJwtException(ErrorCode.UNSUPPORTED_TOKEN);
 		} catch (IllegalArgumentException e) {
 			log.error(ErrorCode.EMPTY_TOKEN_CLAIMS.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.EMPTY_TOKEN_CLAIMS);
+			throw new CustomJwtException(ErrorCode.EMPTY_TOKEN_CLAIMS);
 		} catch (Exception e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 
@@ -154,22 +151,22 @@ public class JwtTokenProvider {
 			return true;
 		} catch (SecurityException e) {
 			log.error(ErrorCode.INVALID_TOKEN_SIGNATURE.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN_SIGNATURE);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN_SIGNATURE);
 		} catch (MalformedJwtException e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		} catch (ExpiredJwtException e) {
 			log.error(ErrorCode.TOKEN_EXPIRED.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+			throw new CustomJwtException(ErrorCode.TOKEN_EXPIRED);
 		} catch (UnsupportedJwtException e) {
 			log.error(ErrorCode.UNSUPPORTED_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+			throw new CustomJwtException(ErrorCode.UNSUPPORTED_TOKEN);
 		} catch (IllegalArgumentException e) {
 			log.error(ErrorCode.EMPTY_TOKEN_CLAIMS.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.EMPTY_TOKEN_CLAIMS);
+			throw new CustomJwtException(ErrorCode.EMPTY_TOKEN_CLAIMS);
 		} catch (Exception e) {
 			log.error(ErrorCode.INVALID_TOKEN.getMessage(), e.getMessage());
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
+			throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 		}
 	}
 
@@ -186,6 +183,6 @@ public class JwtTokenProvider {
 		if (authorization.startsWith("token "))
 			return authorization.substring(6);
 
-		throw new CustomException(ErrorCode.INVALID_TOKEN);
+		throw new CustomJwtException(ErrorCode.INVALID_TOKEN);
 	}
 }


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #37 

## New/Edited policies
-  Spring Security filter의 JWT 예외를 `RestControllerAdvice`를 통해 처리하도록 필터 및 엔트리 포인트 추가